### PR TITLE
Add I18n translations and configurable subdomain/web-console settings

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,9 @@ gem 'telegram-bot', github: 'mprokopov/telegram-bot'
 # Use Active Model has_secure_password [https://guides.rubyonrails.org/active_model_basics.html#securepassword]
 gem 'bcrypt', '~> 3.1.7'
 
+# Rails I18n locale data for common languages [https://github.com/svenfuchs/rails-i18n]
+gem 'rails-i18n', '~> 8.0'
+
 # Admin panel framework [https://github.com/thoughtbot/administrate]
 gem 'administrate', '~> 1.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -398,6 +398,9 @@ GEM
     rails-html-sanitizer (1.6.2)
       loofah (~> 2.21)
       nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
+    rails-i18n (8.1.0)
+      i18n (>= 0.7, < 2)
+      railties (>= 8.0.0, < 9)
     railties (8.1.1)
       actionpack (= 8.1.1)
       activesupport (= 8.1.1)
@@ -604,6 +607,7 @@ DEPENDENCIES
   propshaft
   puma (>= 5.0)
   rails (~> 8.1.1)
+  rails-i18n (~> 8.0)
   redis (~> 5.4)
   request_store
   rubocop-capybara

--- a/config/application.rb
+++ b/config/application.rb
@@ -38,5 +38,12 @@ module Valera
 
     # Analytics configuration
     config.analytics_enabled = ENV.fetch('ANALYTICS_ENABLED', 'true') == 'true'
+
+    # Configure TLD length for subdomain routing
+    # For '3010.brandymint.ru' -> tld_length=2 -> subdomain 'admin' (not 'admin.3010')
+    config.action_dispatch.tld_length = ApplicationConfig.tld_length
+
+    # Configure default URL options for route helpers and mailers
+    Rails.application.routes.default_url_options = ApplicationConfig.default_url_options
   end
 end

--- a/config/application.yml
+++ b/config/application.yml
@@ -1,11 +1,29 @@
 # frozen_string_literal: true
 
 default: &default
+  allowed_hosts: []
+  web_console_permissions: []
 
 development:
   <<: *default
   llm_provider: 'openai'
   llm_model: 'gpt-4o-mini'
+  host: '3010.brandymint.ru'
+  port: 443
+  protocol: 'https'
+  allowed_hosts:
+    - '.lvh.me'
+    - 'lvh.me'
+    - 'localhost'
+    - '.brandymint.ru'
+    - 'brandymint.ru'
+    - '.3010.brandymint.ru'
+    - '3010.brandymint.ru'
+  # Web console permissions - allow local networks
+  web_console_permissions:
+    - '192.168.0.0/16'
+    - '10.0.0.0/8'
+    - '172.16.0.0/12'
 
 production:
   <<: *default

--- a/config/configs/application_config.rb
+++ b/config/configs/application_config.rb
@@ -41,7 +41,19 @@ class ApplicationConfig < Anyway::Config
     llm_temperature: 0.5,
 
     # Development warnings
-    development_warning: true
+    development_warning: true,
+
+    # Allowed hosts for subdomain routing (array or comma-separated string)
+    allowed_hosts: [],
+
+    # Web console permissions (IP addresses/networks)
+    # E.g., ['192.168.0.0/16', '10.0.0.0/8']
+    web_console_permissions: [],
+
+    # Host and port for URL generation and subdomain routing
+    host: 'localhost',
+    port: 3000,
+    protocol: 'http'
   )
 
   # Type coercions to ensure proper data types from environment variables
@@ -76,6 +88,11 @@ class ApplicationConfig < Anyway::Config
     rate_limit_period: :integer,
     max_history_size: :integer,
     webhook_port: :integer,
+    port: :integer,
+
+    # Host and protocol
+    host: :string,
+    protocol: :string,
 
     # Floats
     llm_temperature: :float,
@@ -108,6 +125,24 @@ class ApplicationConfig < Anyway::Config
 
   def welcome_message_template
     File.read(welcome_message_path).presence || raise('No welcome message defined')
+  end
+
+  # Вычисляет tld_length для корректной работы с поддоменами
+  # Для '3010.brandymint.ru' -> 2 (чтобы subdomain был 'admin', а не 'admin.3010')
+  # Для 'localhost' -> 1 (default)
+  def tld_length
+    dots = host.to_s.count('.')
+    dots.positive? ? dots : 1
+  end
+
+  # Опции для генерации URL в routes и mailers
+  def default_url_options
+    options = { host:, protocol: }
+    # Добавляем port только если он нестандартный
+    unless (port.to_s == '80' && protocol == 'http') || (port.to_s == '443' && protocol == 'https')
+      options[:port] = port
+    end
+    options
   end
 
   # Declare required parameters using anyway_config's required method

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -88,4 +88,13 @@ Rails.application.configure do
 
   # Process background jobs inline for development
   config.active_job.queue_adapter = :inline
+
+  # Allow subdomains for admin panel testing (configured via ALLOWED_HOSTS env var)
+  ApplicationConfig.allowed_hosts.each { |host| config.hosts << host }
+
+  # Web console permissions for local network access
+  # Configured via WEB_CONSOLE_PERMISSIONS in config/application.yml
+  if ApplicationConfig.web_console_permissions.any?
+    config.web_console.permissions = ApplicationConfig.web_console_permissions
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
-  # Admin panel with subdomain constraint (admin.*)
+  # Admin panel with subdomain constraint
   constraints subdomain: 'admin' do
     scope module: :admin, as: :admin do
       # Authentication

--- a/test/integration/admin_panel_test.rb
+++ b/test/integration/admin_panel_test.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class AdminPanelTest < ActionDispatch::IntegrationTest
+  test 'time format translation exists for ru locale without raising' do
+    # Use raise: true to ensure translations actually exist (not just fallback)
+    assert_nothing_raised do
+      I18n.t('time.formats.default', locale: :ru, raise: true)
+    end
+  end
+
+  test 'date format translation exists for ru locale without raising' do
+    assert_nothing_raised do
+      I18n.t('date.formats.default', locale: :ru, raise: true)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Add rails-i18n gem for Russian locale date/time translations
- Configure tld_length for proper subdomain parsing (e.g., admin.3010.brandymint.ru)
- Add host/port/protocol configuration to ApplicationConfig
- Add allowed_hosts for config.hosts via ApplicationConfig
- Add web_console_permissions for local network access
- Add default_url_options to routes from ApplicationConfig
- Add integration test for I18n translation existence

## Test plan

- [x] All tests pass (125 runs, 260 assertions)
- [x] Admin panel accessible at admin.3010.brandymint.ru
- [x] Russian translations work for date/time formats
- [x] Web console accessible from local network IPs

🤖 Generated with [Claude Code](https://claude.ai/code)