### PR TITLE
feat(admin): Add role-based access control for AdminUser

### DIFF
--- a/app/controllers/admin/admin_users_controller.rb
+++ b/app/controllers/admin/admin_users_controller.rb
@@ -1,46 +1,15 @@
+# frozen_string_literal: true
+
 module Admin
   class AdminUsersController < Admin::ApplicationController
-    # Overwrite any of the RESTful controller actions to implement custom behavior
-    # For example, you may want to send an email after a foo is updated.
-    #
-    # def update
-    #   super
-    #   send_foo_updated_email(requested_resource)
-    # end
+    before_action :authorize_superuser!
 
-    # Override this method to specify custom lookup behavior.
-    # This will be used to set the resource for the `show`, `edit`, and `update`
-    # actions.
-    #
-    # def find_resource(param)
-    #   Foo.find_by!(slug: param)
-    # end
+    private
 
-    # The result of this lookup will be available as `requested_resource`
+    def authorize_superuser!
+      return if current_admin_user&.superuser?
 
-    # Override this if you have certain roles that require a subset
-    # this will be used to set the records shown on the `index` action.
-    #
-    # def scoped_resource
-    #   if current_user.super_admin?
-    #     resource_class
-    #   else
-    #     resource_class.with_less_stuff
-    #   end
-    # end
-
-    # Override `resource_params` if you want to transform the submitted
-    # data before it's persisted. For example, the following would turn all
-    # empty values into nil values. It uses other APIs such as `resource_class`
-    # and `dashboard`:
-    #
-    # def resource_params
-    #   params.require(resource_class.model_name.param_key).
-    #     permit(dashboard.permitted_attributes(action_name)).
-    #     transform_values { |value| value == "" ? nil : value }
-    # end
-
-    # See https://administrate-demo.herokuapp.com/customizing_controller_actions
-    # for more information
+      redirect_to admin_root_path, alert: 'Access denied. Superuser privileges required.'
+    end
   end
 end

--- a/app/dashboards/admin_user_dashboard.rb
+++ b/app/dashboards/admin_user_dashboard.rb
@@ -7,6 +7,10 @@ class AdminUserDashboard < Administrate::BaseDashboard
     id: Field::Number,
     email: Field::Email,
     password: Field::Password,
+    role: Field::Select.with_options(
+      searchable: false,
+      collection: ->(field) { field.resource.class.roles.keys }
+    ),
     created_at: Field::DateTime,
     updated_at: Field::DateTime
   }.freeze
@@ -14,12 +18,14 @@ class AdminUserDashboard < Administrate::BaseDashboard
   COLLECTION_ATTRIBUTES = %i[
     id
     email
+    role
     created_at
   ].freeze
 
   SHOW_PAGE_ATTRIBUTES = %i[
     id
     email
+    role
     created_at
     updated_at
   ].freeze
@@ -27,6 +33,7 @@ class AdminUserDashboard < Administrate::BaseDashboard
   FORM_ATTRIBUTES = %i[
     email
     password
+    role
   ].freeze
 
   COLLECTION_FILTERS = {}.freeze

--- a/app/models/admin_user.rb
+++ b/app/models/admin_user.rb
@@ -4,5 +4,8 @@ class AdminUser < ApplicationRecord
   has_secure_password
   has_many :managed_leads, class_name: 'Lead', foreign_key: :manager_id, dependent: :nullify, inverse_of: :manager
 
+  enum :role, { manager: 0, superuser: 1 }, default: :manager
+
   validates :email, presence: true, uniqueness: true, 'valid_email_2/email': true
+  validates :role, presence: true
 end

--- a/db/migrate/20251223175959_add_role_to_admin_users.rb
+++ b/db/migrate/20251223175959_add_role_to_admin_users.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddRoleToAdminUsers < ActiveRecord::Migration[8.1]
+  def change
+    # role: 0 = manager (default), 1 = superuser
+    add_column :admin_users, :role, :integer, default: 0, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2025_12_22_193149) do
+ActiveRecord::Schema[8.1].define(version: 2025_12_23_175959) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -46,6 +46,7 @@ ActiveRecord::Schema[8.1].define(version: 2025_12_22_193149) do
     t.datetime "created_at", null: false
     t.string "email"
     t.string "password_digest"
+    t.integer "role", default: 0, null: false
     t.datetime "updated_at", null: false
     t.index ["email"], name: "index_admin_users_on_email", unique: true
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -32,8 +32,9 @@ end
 AdminUser.find_or_create_by!(email: 'admin@example.com') do |admin|
   admin.password = 'password'
   admin.password_confirmation = 'password'
+  admin.role = :superuser
 end
-Rails.logger.info '[Seeds] Default AdminUser created: admin@example.com / password'
+Rails.logger.info '[Seeds] Default AdminUser created: admin@example.com / password (superuser)'
 
 # =============================================================================
 # Dashboard Demo Data (для визуализации dashboard с заполненными данными)

--- a/test/controllers/admin/admin_users_controller_test.rb
+++ b/test/controllers/admin/admin_users_controller_test.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class Admin::AdminUsersControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @superuser = admin_users(:superuser)
+    @manager = admin_users(:manager)
+  end
+
+  test 'superuser can access admin users index' do
+    sign_in_admin(@superuser)
+    get admin_admin_users_path
+    assert_response :success
+  end
+
+  test 'manager cannot access admin users index' do
+    sign_in_admin(@manager)
+    get admin_admin_users_path
+    assert_redirected_to admin_root_path
+    assert_equal 'Access denied. Superuser privileges required.', flash[:alert]
+  end
+
+  test 'superuser can view admin user' do
+    sign_in_admin(@superuser)
+    get admin_admin_user_path(@manager)
+    assert_response :success
+  end
+
+  test 'manager cannot view admin user' do
+    sign_in_admin(@manager)
+    get admin_admin_user_path(@superuser)
+    assert_redirected_to admin_root_path
+  end
+
+  test 'superuser can access new admin user form' do
+    sign_in_admin(@superuser)
+    get new_admin_admin_user_path
+    assert_response :success
+  end
+
+  test 'manager cannot access new admin user form' do
+    sign_in_admin(@manager)
+    get new_admin_admin_user_path
+    assert_redirected_to admin_root_path
+  end
+
+  test 'superuser can create admin user' do
+    sign_in_admin(@superuser)
+    assert_difference('AdminUser.count') do
+      post admin_admin_users_path, params: {
+        admin_user: {
+          email: 'new_admin@example.com',
+          password: 'password123',
+          role: 'manager'
+        }
+      }
+    end
+    assert_redirected_to admin_admin_user_path(AdminUser.last)
+  end
+
+  test 'manager cannot create admin user' do
+    sign_in_admin(@manager)
+    assert_no_difference('AdminUser.count') do
+      post admin_admin_users_path, params: {
+        admin_user: {
+          email: 'new_admin@example.com',
+          password: 'password123',
+          role: 'manager'
+        }
+      }
+    end
+    assert_redirected_to admin_root_path
+  end
+
+  test 'unauthenticated user cannot access admin users' do
+    get admin_admin_users_path
+    assert_redirected_to admin_login_path
+  end
+
+  private
+
+  def sign_in_admin(admin_user)
+    post admin_login_path, params: { email: admin_user.email, password: 'password' }
+  end
+end

--- a/test/fixtures/admin_users.yml
+++ b/test/fixtures/admin_users.yml
@@ -1,9 +1,11 @@
 # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
-one:
-  email: admin_one@example.com
+superuser:
+  email: superuser@example.com
   password_digest: <%= BCrypt::Password.create('password') %>
+  role: 1
 
-two:
-  email: admin_two@example.com
+manager:
+  email: manager@example.com
   password_digest: <%= BCrypt::Password.create('password') %>
+  role: 0

--- a/test/models/admin_user_test.rb
+++ b/test/models/admin_user_test.rb
@@ -36,4 +36,35 @@ class AdminUserTest < ActiveSupport::TestCase
     admin = AdminUser.create!(email: 'auth2@example.com', password: 'password')
     assert_not admin.authenticate('wrong')
   end
+
+  # Role tests
+  test 'default role is manager' do
+    admin = AdminUser.create!(email: 'default_role@example.com', password: 'password')
+    assert admin.manager?
+    assert_not admin.superuser?
+  end
+
+  test 'superuser role' do
+    admin = admin_users(:superuser)
+    assert admin.superuser?
+    assert_not admin.manager?
+  end
+
+  test 'manager role' do
+    admin = admin_users(:manager)
+    assert admin.manager?
+    assert_not admin.superuser?
+  end
+
+  test 'can change role from manager to superuser' do
+    admin = AdminUser.create!(email: 'role_change@example.com', password: 'password')
+    assert admin.manager?
+
+    admin.superuser!
+    assert admin.superuser?
+  end
+
+  test 'role enum values' do
+    assert_equal({ 'manager' => 0, 'superuser' => 1 }, AdminUser.roles)
+  end
 end


### PR DESCRIPTION
## Summary

- Добавлено поле `role` (enum: manager/superuser) в модель AdminUser
- Доступ к `/admin/admin_users` ограничен только для superuser
- Dashboard обновлён для отображения и редактирования ролей
- Первый AdminUser в seeds создаётся с ролью superuser

## Changes

| File | Description |
|------|-------------|
| `db/migrate/*_add_role_to_admin_users.rb` | Миграция: role integer, default: 0, NOT NULL |
| `app/models/admin_user.rb` | Enum role с manager (0) и superuser (1) |
| `app/controllers/admin/admin_users_controller.rb` | before_action authorize_superuser! |
| `app/dashboards/admin_user_dashboard.rb` | Field::Select для роли |
| `db/seeds.rb` | Первый admin с role: :superuser |
| `test/fixtures/admin_users.yml` | Fixtures с ролями |
| `test/models/admin_user_test.rb` | Тесты enum и методов |
| `test/controllers/admin/admin_users_controller_test.rb` | Тесты авторизации |

## Test plan

- [x] Миграция успешно применяется
- [x] Enum корректно работает (проверено через rails runner)
- [x] Superuser имеет доступ к /admin/admin_users
- [x] Manager перенаправляется на admin_root_path
- [ ] Тесты написаны (есть проблема совместимости minitest 6.0 + Rails 8.1)

Closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)