### PR TITLE
feat(admin): Add User ↔ TelegramUser and TenantMembership management

### DIFF
--- a/app/controllers/admin/tenant_memberships_controller.rb
+++ b/app/controllers/admin/tenant_memberships_controller.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+module Admin
+  class TenantMembershipsController < Admin::ApplicationController
+  end
+end

--- a/app/dashboards/telegram_user_dashboard.rb
+++ b/app/dashboards/telegram_user_dashboard.rb
@@ -9,6 +9,8 @@ class TelegramUserDashboard < Administrate::BaseDashboard
     last_name: Field::String,
     username: Field::String,
     photo_url: Field::String,
+    user: Field::HasOne,
+    tenant_memberships: Field::HasMany,
     clients: Field::HasMany,
     chats: Field::HasMany,
     created_at: Field::DateTime,
@@ -20,6 +22,7 @@ class TelegramUserDashboard < Administrate::BaseDashboard
     first_name
     last_name
     username
+    user
     created_at
   ].freeze
 
@@ -29,6 +32,8 @@ class TelegramUserDashboard < Administrate::BaseDashboard
     last_name
     username
     photo_url
+    user
+    tenant_memberships
     clients
     chats
     created_at

--- a/app/dashboards/tenant_membership_dashboard.rb
+++ b/app/dashboards/tenant_membership_dashboard.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require 'administrate/base_dashboard'
+
+class TenantMembershipDashboard < Administrate::BaseDashboard
+  ATTRIBUTE_TYPES = {
+    id: Field::Number,
+    tenant: Field::BelongsTo,
+    user: Field::BelongsTo,
+    invited_by: Field::BelongsTo.with_options(class_name: 'User'),
+    role: Field::Select.with_options(searchable: false, collection: ->(field) { field.resource.class.roles.keys }),
+    created_at: Field::DateTime,
+    updated_at: Field::DateTime
+  }.freeze
+
+  COLLECTION_ATTRIBUTES = %i[
+    id
+    tenant
+    user
+    role
+    created_at
+  ].freeze
+
+  SHOW_PAGE_ATTRIBUTES = %i[
+    id
+    tenant
+    user
+    invited_by
+    role
+    created_at
+    updated_at
+  ].freeze
+
+  FORM_ATTRIBUTES = %i[
+    tenant
+    user
+    invited_by
+    role
+  ].freeze
+
+  COLLECTION_FILTERS = {}.freeze
+
+  def display_resource(tenant_membership)
+    "#{tenant_membership.user&.name || 'User'} @ #{tenant_membership.tenant&.name || 'Tenant'}"
+  end
+end

--- a/app/dashboards/user_dashboard.rb
+++ b/app/dashboards/user_dashboard.rb
@@ -7,7 +7,9 @@ class UserDashboard < Administrate::BaseDashboard
     id: Field::Number,
     email: Field::Email,
     name: Field::String,
+    telegram_user: Field::BelongsTo,
     owned_tenants: Field::HasMany,
+    tenant_memberships: Field::HasMany,
     created_at: Field::DateTime,
     updated_at: Field::DateTime
   }.freeze
@@ -16,6 +18,7 @@ class UserDashboard < Administrate::BaseDashboard
     id
     name
     email
+    telegram_user
     owned_tenants
   ].freeze
 
@@ -23,7 +26,9 @@ class UserDashboard < Administrate::BaseDashboard
     id
     name
     email
+    telegram_user
     owned_tenants
+    tenant_memberships
     created_at
     updated_at
   ].freeze
@@ -31,6 +36,7 @@ class UserDashboard < Administrate::BaseDashboard
   FORM_ATTRIBUTES = %i[
     name
     email
+    telegram_user
   ].freeze
 
   COLLECTION_FILTERS = {}.freeze

--- a/app/models/telegram_user.rb
+++ b/app/models/telegram_user.rb
@@ -23,6 +23,8 @@
 class TelegramUser < ApplicationRecord
   has_many :clients, dependent: :destroy
   has_many :chats, dependent: :destroy
+  has_one :user, dependent: :nullify
+  has_many :tenant_memberships, through: :user
 
   # Возвращает имя пользователя для отображения
   #

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,6 +19,7 @@ Rails.application.routes.draw do
       resources :admin_users
       resources :leads
       resources :telegram_users, only: %i[index show]
+      resources :tenant_memberships
 
       root to: 'tenants#index'
     end


### PR DESCRIPTION
## Summary

- Расширена Administrate админка для управления связями User ↔ TelegramUser
- Добавлено полноценное управление TenantMembership с CRUD операциями
- TelegramUserDashboard теперь показывает связанного User и его tenant_memberships

## Changes

### UserDashboard
- ✅ Добавлен `telegram_user` (BelongsTo) — выбор Telegram-аккаунта в форме
- ✅ Добавлен `tenant_memberships` (HasMany) — отображение на странице show

### TelegramUserDashboard
- ✅ Добавлен `user` (HasOne) — связанный пользователь системы
- ✅ Добавлен `tenant_memberships` (HasMany through user)

### TelegramUser model
- ✅ `has_one :user, dependent: :nullify`
- ✅ `has_many :tenant_memberships, through: :user`

### TenantMembershipDashboard (новый)
- ✅ Полный CRUD: create, read, update, delete
- ✅ Role как select с enum значениями (viewer, operator, admin)
- ✅ Связи: tenant, user, invited_by

### Routes
- ✅ `resources :tenant_memberships` в admin namespace
- ✅ Навигация в sidebar автоматически включает TenantMemberships

## Test plan

- [x] Все 296 тестов проходят
- [x] Rubocop без нарушений
- [ ] Проверить в браузере: связывание User с TelegramUser
- [ ] Проверить в браузере: просмотр User в TelegramUser
- [ ] Проверить в браузере: CRUD для TenantMembership
- [ ] Проверить: Role отображается как select

Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)