### PR TITLE
Refactor: Вынести инвайты в отдельную модель TenantInvite

### DIFF
--- a/app/controllers/admin/tenant_invites_controller.rb
+++ b/app/controllers/admin/tenant_invites_controller.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module Admin
+  class TenantInvitesController < Admin::ApplicationController
+    # Administrate автоматически обрабатывает CRUD операции
+    # Настройки отображения определены в TenantInviteDashboard
+  end
+end

--- a/app/dashboards/tenant_invite_dashboard.rb
+++ b/app/dashboards/tenant_invite_dashboard.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require 'administrate/base_dashboard'
+
+class TenantInviteDashboard < Administrate::BaseDashboard
+  ATTRIBUTE_TYPES = {
+    id: Field::Number,
+    tenant: Field::BelongsTo,
+    invited_by: Field::BelongsTo.with_options(class_name: 'User'),
+    accepted_by: Field::BelongsTo.with_options(class_name: 'User'),
+    token: Field::String,
+    role: Field::Select.with_options(
+      collection: ->(field) { field.resource.class.roles.keys }
+    ),
+    status: Field::Select.with_options(
+      collection: ->(field) { field.resource.class.statuses.keys }
+    ),
+    expires_at: Field::DateTime,
+    accepted_at: Field::DateTime,
+    cancelled_at: Field::DateTime,
+    created_at: Field::DateTime,
+    updated_at: Field::DateTime
+  }.freeze
+
+  COLLECTION_ATTRIBUTES = %i[
+    id
+    tenant
+    invited_by
+    role
+    status
+    expires_at
+    created_at
+  ].freeze
+
+  SHOW_PAGE_ATTRIBUTES = %i[
+    id
+    tenant
+    invited_by
+    accepted_by
+    token
+    role
+    status
+    expires_at
+    accepted_at
+    cancelled_at
+    created_at
+    updated_at
+  ].freeze
+
+  FORM_ATTRIBUTES = %i[
+    tenant
+    invited_by
+    role
+    status
+    expires_at
+  ].freeze
+
+  COLLECTION_FILTERS = {
+    pending: ->(resources) { resources.pending },
+    accepted: ->(resources) { resources.accepted },
+    cancelled: ->(resources) { resources.cancelled },
+    active: ->(resources) { resources.active }
+  }.freeze
+
+  def display_resource(invite)
+    "Invite ##{invite.id} (#{invite.role})"
+  end
+end

--- a/app/models/tenant.rb
+++ b/app/models/tenant.rb
@@ -12,6 +12,7 @@ class Tenant < ApplicationRecord
 
   has_many :tenant_memberships, dependent: :destroy
   has_many :members, through: :tenant_memberships, source: :user
+  has_many :tenant_invites, dependent: :destroy
   has_many :clients, dependent: :destroy
   has_many :chats, dependent: :destroy
   has_many :bookings, dependent: :destroy

--- a/app/models/tenant_invite.rb
+++ b/app/models/tenant_invite.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+# Приглашение участника в tenant
+#
+# Заменяет хранение инвайтов в Redis на персистентное хранилище.
+# Позволяет:
+# - Видеть список активных инвайтов
+# - Отменять инвайты
+# - Отслеживать историю приглашений
+#
+# @example Создание инвайта
+#   invite = TenantInvite.create!(
+#     tenant: tenant,
+#     invited_by: admin_user,
+#     role: :operator,
+#     expires_at: 7.days.from_now
+#   )
+#   invite.telegram_url # => "https://t.me/bot?start=MBR_xxx"
+#
+# @example Принятие инвайта
+#   invite = TenantInvite.active.find_by!(token: 'MBR_xxx')
+#   invite.accept!(user)
+#
+class TenantInvite < ApplicationRecord
+  belongs_to :tenant
+  belongs_to :invited_by, class_name: 'User'
+  belongs_to :accepted_by, class_name: 'User', optional: true
+
+  enum :role, { viewer: 0, operator: 1, admin: 2 }
+  enum :status, { pending: 0, accepted: 1, expired: 2, cancelled: 3 }
+
+  validates :token, presence: true, uniqueness: true
+  validates :role, presence: true
+  validates :expires_at, presence: true
+
+  scope :active, -> { pending.where('expires_at > ?', Time.current) }
+
+  before_validation :generate_token, on: :create
+
+  # Принимает инвайт и связывает с пользователем
+  #
+  # @param user [User] пользователь, принимающий инвайт
+  # @return [Boolean]
+  def accept!(user)
+    update!(status: :accepted, accepted_by: user, accepted_at: Time.current)
+  end
+
+  # Отменяет инвайт
+  #
+  # @return [Boolean]
+  def cancel!
+    update!(status: :cancelled, cancelled_at: Time.current)
+  end
+
+  # Проверяет истёк ли инвайт
+  #
+  # @return [Boolean]
+  def expired?
+    pending? && expires_at < Time.current
+  end
+
+  # Возвращает Telegram URL для инвайта
+  #
+  # @return [String]
+  def telegram_url
+    "https://t.me/#{ApplicationConfig.platform_bot_username}?start=#{token}"
+  end
+
+  private
+
+  def generate_token
+    self.token ||= "MBR_#{SecureRandom.urlsafe_base64(12)}"
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,6 +20,7 @@ Rails.application.routes.draw do
       resources :leads
       resources :telegram_users, only: %i[index show]
       resources :tenant_memberships
+      resources :tenant_invites, only: %i[index show]
 
       root to: 'tenants#index'
     end
@@ -54,6 +55,7 @@ Rails.application.routes.draw do
       resources :members, only: %i[index create destroy] do
         collection do
           get :invite
+          delete 'invites/:id', action: :cancel_invite, as: :cancel_invite
         end
       end
       resource :settings, only: %i[edit update]

--- a/db/migrate/20251226070451_create_tenant_invites.rb
+++ b/db/migrate/20251226070451_create_tenant_invites.rb
@@ -1,0 +1,19 @@
+class CreateTenantInvites < ActiveRecord::Migration[8.1]
+  def change
+    create_table :tenant_invites do |t|
+      t.references :tenant, null: false, foreign_key: true
+      t.references :invited_by, null: false, foreign_key: { to_table: :users }
+      t.references :accepted_by, foreign_key: { to_table: :users }
+      t.string :token, null: false
+      t.integer :role, null: false, default: 0
+      t.integer :status, null: false, default: 0
+      t.datetime :expires_at, null: false
+      t.datetime :accepted_at
+      t.datetime :cancelled_at
+
+      t.timestamps
+    end
+    add_index :tenant_invites, :token, unique: true
+    add_index :tenant_invites, %i[tenant_id status]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2025_12_23_175959) do
+ActiveRecord::Schema[8.1].define(version: 2025_12_26_070451) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -175,6 +175,25 @@ ActiveRecord::Schema[8.1].define(version: 2025_12_23_175959) do
     t.string "username"
   end
 
+  create_table "tenant_invites", force: :cascade do |t|
+    t.datetime "accepted_at"
+    t.bigint "accepted_by_id"
+    t.datetime "cancelled_at"
+    t.datetime "created_at", null: false
+    t.datetime "expires_at", null: false
+    t.bigint "invited_by_id", null: false
+    t.integer "role", default: 0, null: false
+    t.integer "status", default: 0, null: false
+    t.bigint "tenant_id", null: false
+    t.string "token", null: false
+    t.datetime "updated_at", null: false
+    t.index ["accepted_by_id"], name: "index_tenant_invites_on_accepted_by_id"
+    t.index ["invited_by_id"], name: "index_tenant_invites_on_invited_by_id"
+    t.index ["tenant_id", "status"], name: "index_tenant_invites_on_tenant_id_and_status"
+    t.index ["tenant_id"], name: "index_tenant_invites_on_tenant_id"
+    t.index ["token"], name: "index_tenant_invites_on_token", unique: true
+  end
+
   create_table "tenant_memberships", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.bigint "invited_by_id"
@@ -252,6 +271,9 @@ ActiveRecord::Schema[8.1].define(version: 2025_12_23_175959) do
   add_foreign_key "clients", "tenants"
   add_foreign_key "leads", "admin_users", column: "manager_id"
   add_foreign_key "messages", "chats"
+  add_foreign_key "tenant_invites", "tenants"
+  add_foreign_key "tenant_invites", "users", column: "accepted_by_id"
+  add_foreign_key "tenant_invites", "users", column: "invited_by_id"
   add_foreign_key "tenant_memberships", "tenants"
   add_foreign_key "tenant_memberships", "users"
   add_foreign_key "tenant_memberships", "users", column: "invited_by_id"

--- a/test/fixtures/tenant_invites.yml
+++ b/test/fixtures/tenant_invites.yml
@@ -1,0 +1,36 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+pending_invite:
+  tenant: one
+  invited_by: one
+  token: MBR_pending_test_token
+  role: 1
+  status: 0
+  expires_at: <%= 7.days.from_now.to_fs(:db) %>
+
+accepted_invite:
+  tenant: one
+  invited_by: one
+  accepted_by: two
+  token: MBR_accepted_test_token
+  role: 1
+  status: 1
+  expires_at: <%= 7.days.from_now.to_fs(:db) %>
+  accepted_at: <%= 1.day.ago.to_fs(:db) %>
+
+expired_invite:
+  tenant: one
+  invited_by: one
+  token: MBR_expired_test_token
+  role: 0
+  status: 0
+  expires_at: <%= 1.day.ago.to_fs(:db) %>
+
+cancelled_invite:
+  tenant: two
+  invited_by: two
+  token: MBR_cancelled_test_token
+  role: 2
+  status: 3
+  expires_at: <%= 7.days.from_now.to_fs(:db) %>
+  cancelled_at: <%= 1.day.ago.to_fs(:db) %>

--- a/test/models/tenant_invite_test.rb
+++ b/test/models/tenant_invite_test.rb
@@ -1,0 +1,167 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class TenantInviteTest < ActiveSupport::TestCase
+  setup do
+    @tenant = tenants(:one)
+    @user = users(:one)
+  end
+
+  test 'generates token on create' do
+    invite = TenantInvite.create!(
+      tenant: @tenant,
+      invited_by: @user,
+      role: :operator,
+      expires_at: 7.days.from_now
+    )
+
+    assert_not_nil invite.token
+    assert invite.token.start_with?('MBR_'), 'Token must start with MBR_'
+  end
+
+  test 'has default role of viewer' do
+    invite = TenantInvite.new(
+      tenant: @tenant,
+      invited_by: @user,
+      expires_at: 7.days.from_now
+    )
+
+    assert invite.valid?
+    assert_equal 'viewer', invite.role
+  end
+
+  test 'validates presence of expires_at' do
+    invite = TenantInvite.new(
+      tenant: @tenant,
+      invited_by: @user,
+      role: :operator
+    )
+
+    assert_not invite.valid?
+    assert invite.errors[:expires_at].present?
+  end
+
+  test 'validates token uniqueness' do
+    invite1 = TenantInvite.create!(
+      tenant: @tenant,
+      invited_by: @user,
+      role: :operator,
+      expires_at: 7.days.from_now
+    )
+
+    invite2 = TenantInvite.new(
+      tenant: @tenant,
+      invited_by: @user,
+      role: :viewer,
+      token: invite1.token,
+      expires_at: 7.days.from_now
+    )
+
+    assert_not invite2.valid?
+    assert invite2.errors[:token].present?
+  end
+
+  test 'active scope returns pending invites not expired' do
+    active_invite = TenantInvite.create!(
+      tenant: @tenant,
+      invited_by: @user,
+      role: :operator,
+      expires_at: 7.days.from_now
+    )
+
+    expired_invite = TenantInvite.create!(
+      tenant: @tenant,
+      invited_by: @user,
+      role: :viewer,
+      expires_at: 1.day.ago
+    )
+
+    assert_includes TenantInvite.active, active_invite
+    assert_not_includes TenantInvite.active, expired_invite
+  end
+
+  test 'accept! updates status and accepted_by' do
+    invite = TenantInvite.create!(
+      tenant: @tenant,
+      invited_by: @user,
+      role: :operator,
+      expires_at: 7.days.from_now
+    )
+
+    accepting_user = users(:two)
+    invite.accept!(accepting_user)
+
+    assert invite.accepted?
+    assert_equal accepting_user, invite.accepted_by
+    assert_not_nil invite.accepted_at
+  end
+
+  test 'cancel! updates status and cancelled_at' do
+    invite = TenantInvite.create!(
+      tenant: @tenant,
+      invited_by: @user,
+      role: :operator,
+      expires_at: 7.days.from_now
+    )
+
+    invite.cancel!
+
+    assert invite.cancelled?
+    assert_not_nil invite.cancelled_at
+  end
+
+  test 'expired? returns true for pending invites past expiration' do
+    invite = TenantInvite.create!(
+      tenant: @tenant,
+      invited_by: @user,
+      role: :operator,
+      expires_at: 1.day.ago
+    )
+
+    assert invite.expired?
+  end
+
+  test 'expired? returns false for active invites' do
+    invite = TenantInvite.create!(
+      tenant: @tenant,
+      invited_by: @user,
+      role: :operator,
+      expires_at: 7.days.from_now
+    )
+
+    assert_not invite.expired?
+  end
+
+  test 'expired? returns false for accepted invites' do
+    invite = TenantInvite.create!(
+      tenant: @tenant,
+      invited_by: @user,
+      role: :operator,
+      expires_at: 1.day.ago,
+      status: :accepted
+    )
+
+    assert_not invite.expired?
+  end
+
+  test 'telegram_url generates correct URL' do
+    invite = TenantInvite.create!(
+      tenant: @tenant,
+      invited_by: @user,
+      role: :operator,
+      expires_at: 7.days.from_now
+    )
+
+    expected_url = "https://t.me/#{ApplicationConfig.platform_bot_username}?start=#{invite.token}"
+    assert_equal expected_url, invite.telegram_url
+  end
+
+  test 'role enum has viewer, operator, admin' do
+    assert_equal({ 'viewer' => 0, 'operator' => 1, 'admin' => 2 }, TenantInvite.roles)
+  end
+
+  test 'status enum has pending, accepted, expired, cancelled' do
+    assert_equal({ 'pending' => 0, 'accepted' => 1, 'expired' => 2, 'cancelled' => 3 }, TenantInvite.statuses)
+  end
+end

--- a/test/services/telegram_auth_service_test.rb
+++ b/test/services/telegram_auth_service_test.rb
@@ -135,62 +135,6 @@ class TelegramAuthServiceTest < ActiveSupport::TestCase
     assert_nil data
   end
 
-  # === Member Invite Token Tests ===
-
-  test 'creates member invite token' do
-    token = @service.create_member_invite_token(
-      tenant_id: @tenant.id,
-      role: :operator,
-      invited_by_user_id: @user.id
-    )
-
-    assert_not_nil token
-    assert token.start_with?('MBR_'), 'Member invite token must start with MBR_'
-  end
-
-  test 'consumes valid member invite token' do
-    token = @service.create_member_invite_token(
-      tenant_id: @tenant.id,
-      role: :operator,
-      invited_by_user_id: @user.id
-    )
-
-    data = @service.consume_member_invite_token(token)
-
-    assert_not_nil data
-    assert_equal @tenant.id, data[:tenant_id]
-    assert_equal 'operator', data[:role]
-    assert_equal @user.id, data[:invited_by_user_id]
-  end
-
-  test 'consume removes member invite token' do
-    token = @service.create_member_invite_token(
-      tenant_id: @tenant.id,
-      role: :viewer,
-      invited_by_user_id: @user.id
-    )
-
-    @service.consume_member_invite_token(token)
-    data = @service.consume_member_invite_token(token)
-
-    assert_nil data, 'Member invite token should be consumed only once'
-  end
-
-  test 'returns nil for invalid member invite token' do
-    data = @service.consume_member_invite_token('MBR_invalid')
-    assert_nil data
-  end
-
-  test 'member_invite? returns true for MBR_ tokens' do
-    assert @service.member_invite?('MBR_abc123')
-  end
-
-  test 'member_invite? returns false for other tokens' do
-    assert_not @service.member_invite?('INV_abc123')
-    assert_not @service.member_invite?('GLB_abc123')
-    assert_not @service.member_invite?('abc123')
-  end
-
   # === Link User Tests ===
 
   test 'links user to telegram user' do


### PR DESCRIPTION
## Summary

- Создана модель `TenantInvite` для хранения приглашений участников в БД вместо Redis
- Добавлены enums для role (viewer/operator/admin) и status (pending/accepted/expired/cancelled)
- Обновлены MembersController и PlatformBotController для использования новой модели
- Добавлен Administrate dashboard для просмотра инвайтов в админке
- Удалён устаревший код member_invite из TelegramAuthService

## Changes

### Model & Migration
- `TenantInvite` с полями: tenant_id, invited_by_id, accepted_by_id, token, role, status, expires_at, accepted_at, cancelled_at
- Scope `active` для получения pending инвайтов, которые ещё не истекли
- Методы: `accept!(user)`, `cancel!`, `expired?`, `telegram_url`

### Controllers
- `MembersController#create` создаёт TenantInvite вместо Redis токена
- `MembersController#cancel_invite` для отмены pending инвайтов
- `PlatformBotController#handle_member_invite` использует `TenantInvite.active.find_by(token:)`

### Admin
- Dashboard с фильтрами: pending, accepted, cancelled, active

## Test plan

- [x] Все 303 теста проходят
- [x] Rubocop без нарушений
- [ ] Проверить создание инвайта через UI
- [ ] Проверить принятие инвайта через Telegram бота
- [ ] Проверить отмену инвайта через UI
- [ ] Проверить просмотр инвайтов в админке

Closes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)