### PR TITLE
feat(admin): Add tenant invite management for admins

### DIFF
--- a/app/controllers/admin/tenants/invites_controller.rb
+++ b/app/controllers/admin/tenants/invites_controller.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module Admin
+  module Tenants
+    # Контроллер для управления приглашениями участников tenant из admin-панели
+    #
+    # Позволяет менеджерам создавать приглашения для владельцев и сотрудников.
+    class InvitesController < Admin::ApplicationController
+      before_action :set_tenant
+
+      # POST /admin/tenants/:tenant_id/invites
+      # Создаёт приглашение для tenant
+      def create
+        @invite = @tenant.tenant_invites.build(invite_params)
+        @invite.invited_by_admin = current_admin_user
+        @invite.expires_at = ApplicationConfig.tenant_invite_expiration_days.days.from_now
+
+        if @invite.save
+          redirect_to [ :admin, @tenant ], notice: t('.success', telegram_url: @invite.telegram_url)
+        else
+          redirect_to [ :admin, @tenant ], alert: @invite.errors.full_messages.to_sentence
+        end
+      end
+
+      # DELETE /admin/tenants/:tenant_id/invites/:id
+      # Отменяет приглашение
+      def destroy
+        @invite = @tenant.tenant_invites.find(params[:id])
+        @invite.cancel!
+
+        redirect_to [ :admin, @tenant ], notice: t('.success')
+      end
+
+      private
+
+      def set_tenant
+        @tenant = Tenant.find(params[:tenant_id])
+      end
+
+      def invite_params
+        params.require(:tenant_invite).permit(:role)
+      end
+    end
+  end
+end

--- a/app/dashboards/tenant_dashboard.rb
+++ b/app/dashboards/tenant_dashboard.rb
@@ -72,7 +72,7 @@ class TenantDashboard < Administrate::BaseDashboard
   ].freeze
 
   SHOW_PAGE_ATTRIBUTES = {
-    "" => %i[
+    '' => %i[
       id
       name
       subdomain
@@ -86,33 +86,33 @@ class TenantDashboard < Administrate::BaseDashboard
       created_at
       updated_at
     ],
-    "Telegram" => %i[
+    'Telegram' => %i[
       bot_username
       bot_token
       webhook_secret
       admin_chat_id
     ],
-    "Информация о компании" => %i[company_info],
-    "Прайс-лист" => %i[price_list],
-    "Приветствие" => %i[welcome_message],
-    "Системный промпт" => %i[system_prompt]
+    'Информация о компании' => %i[company_info],
+    'Прайс-лист' => %i[price_list],
+    'Приветствие' => %i[welcome_message],
+    'Системный промпт' => %i[system_prompt]
   }.freeze
 
   FORM_ATTRIBUTES = {
-    "Основное" => %i[
+    'Основное' => %i[
       name
       subdomain
       owner_and_manager
     ],
-    "Telegram" => %i[
+    'Telegram' => %i[
       bot_token
       bot_username
       admin_chat_id
     ],
-    "Информация о компании" => %i[company_info],
-    "Прайс-лист" => %i[price_list],
-    "Приветствие" => %i[welcome_message],
-    "Системный промпт" => %i[system_prompt]
+    'Информация о компании' => %i[company_info],
+    'Прайс-лист' => %i[price_list],
+    'Приветствие' => %i[welcome_message],
+    'Системный промпт' => %i[system_prompt]
   }.freeze
 
   COLLECTION_FILTERS = {}.freeze

--- a/app/dashboards/tenant_invite_dashboard.rb
+++ b/app/dashboards/tenant_invite_dashboard.rb
@@ -6,7 +6,8 @@ class TenantInviteDashboard < Administrate::BaseDashboard
   ATTRIBUTE_TYPES = {
     id: Field::Number,
     tenant: Field::BelongsTo,
-    invited_by: Field::BelongsTo.with_options(class_name: 'User'),
+    invited_by_user: Field::BelongsTo.with_options(class_name: 'User'),
+    invited_by_admin: Field::BelongsTo.with_options(class_name: 'AdminUser'),
     accepted_by: Field::BelongsTo.with_options(class_name: 'User'),
     token: Field::String,
     role: Field::Select.with_options(
@@ -19,13 +20,13 @@ class TenantInviteDashboard < Administrate::BaseDashboard
     accepted_at: Field::DateTime,
     cancelled_at: Field::DateTime,
     created_at: Field::DateTime,
-    updated_at: Field::DateTime
+    updated_at: Field::DateTime,
+    telegram_url: Field::String
   }.freeze
 
   COLLECTION_ATTRIBUTES = %i[
     id
     tenant
-    invited_by
     role
     status
     expires_at
@@ -35,9 +36,11 @@ class TenantInviteDashboard < Administrate::BaseDashboard
   SHOW_PAGE_ATTRIBUTES = %i[
     id
     tenant
-    invited_by
+    invited_by_user
+    invited_by_admin
     accepted_by
     token
+    telegram_url
     role
     status
     expires_at
@@ -49,9 +52,7 @@ class TenantInviteDashboard < Administrate::BaseDashboard
 
   FORM_ATTRIBUTES = %i[
     tenant
-    invited_by
     role
-    status
     expires_at
   ].freeze
 

--- a/app/views/admin/tenants/_invites_section.html.erb
+++ b/app/views/admin/tenants/_invites_section.html.erb
@@ -1,0 +1,62 @@
+<%# Секция приглашений участников tenant %>
+<fieldset class="field-unit--nested">
+  <legend>Приглашения</legend>
+
+  <div class="invites-section">
+    <%# Кнопки создания приглашений %>
+    <div class="invites-actions" style="margin-bottom: 1rem;">
+      <% TenantInvite.roles.keys.each do |role| %>
+        <%= form_with url: admin_tenant_invites_path(tenant), method: :post, style: "display: inline-block; margin-right: 0.5rem;" do |f| %>
+          <%= f.hidden_field :role, value: role %>
+          <%= f.submit "Пригласить #{t("platform_bot.roles.#{role}", default: role)}", class: "button" %>
+        <% end %>
+      <% end %>
+    </div>
+
+    <%# Список активных приглашений %>
+    <% active_invites = tenant.tenant_invites.active %>
+    <% if active_invites.any? %>
+      <h4 style="margin-top: 1rem;">Активные приглашения</h4>
+      <table class="collection-data">
+        <thead>
+          <tr>
+            <th>Роль</th>
+            <th>Создано</th>
+            <th>Истекает</th>
+            <th>Telegram ссылка</th>
+            <th>Действия</th>
+          </tr>
+        </thead>
+        <tbody>
+          <% active_invites.each do |invite| %>
+            <tr>
+              <td><%= t("platform_bot.roles.#{invite.role}", default: invite.role) %></td>
+              <td><%= l(invite.created_at, format: :short) %></td>
+              <td><%= l(invite.expires_at, format: :short) %></td>
+              <td>
+                <div style="display: flex; align-items: center; gap: 0.5rem;">
+                  <code style="font-size: 0.8em; max-width: 300px; overflow: hidden; text-overflow: ellipsis;"><%= invite.telegram_url %></code>
+                  <button type="button"
+                          class="button button--small"
+                          onclick="navigator.clipboard.writeText('<%= invite.telegram_url %>').then(() => alert('Ссылка скопирована!'))"
+                          title="Копировать ссылку">
+                    Копировать
+                  </button>
+                </div>
+              </td>
+              <td>
+                <%= button_to "Отменить",
+                              admin_tenant_invite_path(tenant, invite),
+                              method: :delete,
+                              class: "button button--small button--danger",
+                              data: { turbo_confirm: "Отменить это приглашение?" } %>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    <% else %>
+      <p style="color: #666; font-style: italic;">Нет активных приглашений</p>
+    <% end %>
+  </div>
+</fieldset>

--- a/app/views/admin/tenants/show.html.erb
+++ b/app/views/admin/tenants/show.html.erb
@@ -51,4 +51,6 @@ Extends the default Administrate show page with grouped attributes.
       </fieldset>
     <% end %>
   </dl>
+
+  <%= render 'admin/tenants/invites_section', tenant: page.resource %>
 </section>

--- a/config/application.yml
+++ b/config/application.yml
@@ -49,6 +49,9 @@ default: &default
   # Telegram Auth settings
   telegram_auth_expiration: 300
 
+  # Tenant invite expiration (in days)
+  tenant_invite_expiration_days: 7
+
   # Reserved subdomains (cannot be used as tenant keys)
   reserved_subdomains:
     - www

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -1,0 +1,10 @@
+{
+  "ignored_warnings": [
+    {
+      "fingerprint": "713c413be63edd287ab2d1ebf540dbfe5431c82f93fa1f5dd5d92984c8f15a05",
+      "note": "Role is an enum field, validated by the model. Only :viewer, :operator, :admin are accepted. False positive."
+    }
+  ],
+  "updated": "2025-12-27 12:10:00 +0300",
+  "brakeman_version": "7.1.2"
+}

--- a/config/configs/application_config.rb
+++ b/config/configs/application_config.rb
@@ -81,7 +81,10 @@ class ApplicationConfig < Anyway::Config
     :telegram_auth_expiration,
 
     # Reserved subdomains that cannot be used as tenant keys
-    :reserved_subdomains
+    :reserved_subdomains,
+
+    # Tenant invite expiration (in days)
+    :tenant_invite_expiration_days
   )
 
   # Type coercions to ensure proper data types from environment variables
@@ -135,6 +138,9 @@ class ApplicationConfig < Anyway::Config
     platform_bot_username: :string,
     platform_admin_chat_id: :string,
     telegram_auth_expiration: :integer,
+
+    # Tenant invites
+    tenant_invite_expiration_days: :integer,
 
     # Admin host
     admin_host: :string,

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -77,6 +77,11 @@ ru:
         destroy:
           success: "Webhook удален"
           error: "Ошибка: %{message}"
+      invites:
+        create:
+          success: "Приглашение создано. Telegram ссылка: %{telegram_url}"
+        destroy:
+          success: "Приглашение отменено"
     impersonations:
       impersonate_button: Войти как
       confirm: "Вы уверены, что хотите войти как %{name}?"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,8 @@ Rails.application.routes.draw do
       resources :tenants do
         # Telegram webhook management (singular resource)
         resource :webhook, only: %i[show create destroy], module: :tenants
+        # Tenant invites (для приглашения сотрудников менеджером)
+        resources :invites, only: %i[create destroy], controller: 'tenants/invites'
       end
       resources :users
       resources :admin_users do
@@ -33,7 +35,7 @@ Rails.application.routes.draw do
       resources :bookings, only: %i[index show]
 
       # Mission Control Jobs - SolidQueue monitoring dashboard
-      mount MissionControl::Jobs::Engine, at: "/jobs"
+      mount MissionControl::Jobs::Engine, at: '/jobs'
 
       root to: 'tenants#index'
     end

--- a/db/migrate/20251227085244_add_invited_by_admin_to_tenant_invites.rb
+++ b/db/migrate/20251227085244_add_invited_by_admin_to_tenant_invites.rb
@@ -1,0 +1,8 @@
+class AddInvitedByAdminToTenantInvites < ActiveRecord::Migration[8.1]
+  def change
+    rename_column :tenant_invites, :invited_by_id, :invited_by_user_id
+    change_column_null :tenant_invites, :invited_by_user_id, true
+    add_reference :tenant_invites, :invited_by_admin,
+                  foreign_key: { to_table: :admin_users }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2025_12_26_182120) do
+ActiveRecord::Schema[8.1].define(version: 2025_12_27_085244) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -183,14 +183,16 @@ ActiveRecord::Schema[8.1].define(version: 2025_12_26_182120) do
     t.datetime "cancelled_at"
     t.datetime "created_at", null: false
     t.datetime "expires_at", null: false
-    t.bigint "invited_by_id", null: false
+    t.bigint "invited_by_admin_id"
+    t.bigint "invited_by_user_id"
     t.integer "role", default: 0, null: false
     t.integer "status", default: 0, null: false
     t.bigint "tenant_id", null: false
     t.string "token", null: false
     t.datetime "updated_at", null: false
     t.index ["accepted_by_id"], name: "index_tenant_invites_on_accepted_by_id"
-    t.index ["invited_by_id"], name: "index_tenant_invites_on_invited_by_id"
+    t.index ["invited_by_admin_id"], name: "index_tenant_invites_on_invited_by_admin_id"
+    t.index ["invited_by_user_id"], name: "index_tenant_invites_on_invited_by_user_id"
     t.index ["tenant_id", "status"], name: "index_tenant_invites_on_tenant_id_and_status"
     t.index ["tenant_id"], name: "index_tenant_invites_on_tenant_id"
     t.index ["token"], name: "index_tenant_invites_on_token", unique: true
@@ -279,9 +281,10 @@ ActiveRecord::Schema[8.1].define(version: 2025_12_26_182120) do
   add_foreign_key "clients", "tenants"
   add_foreign_key "leads", "admin_users", column: "manager_id"
   add_foreign_key "messages", "chats"
+  add_foreign_key "tenant_invites", "admin_users", column: "invited_by_admin_id"
   add_foreign_key "tenant_invites", "tenants"
   add_foreign_key "tenant_invites", "users", column: "accepted_by_id"
-  add_foreign_key "tenant_invites", "users", column: "invited_by_id"
+  add_foreign_key "tenant_invites", "users", column: "invited_by_user_id"
   add_foreign_key "tenant_memberships", "tenants"
   add_foreign_key "tenant_memberships", "users"
   add_foreign_key "tenant_memberships", "users", column: "invited_by_id"

--- a/test/controllers/admin/tenants/invites_controller_test.rb
+++ b/test/controllers/admin/tenants/invites_controller_test.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module Admin
+  module Tenants
+    class InvitesControllerTest < ActionDispatch::IntegrationTest
+      setup do
+        @tenant = tenants(:one)
+        @admin_user = admin_users(:superuser)
+        host! "admin.#{ApplicationConfig.host}"
+        sign_in_admin(@admin_user)
+      end
+
+      test 'create creates invite with invited_by_admin' do
+        assert_difference -> { TenantInvite.count }, 1 do
+          post admin_tenant_invites_path(@tenant), params: {
+            tenant_invite: { role: 'operator' }
+          }
+        end
+
+        assert_redirected_to [ :admin, @tenant ]
+
+        invite = TenantInvite.last
+        assert_equal @tenant, invite.tenant
+        assert_equal @admin_user, invite.invited_by_admin
+        assert_nil invite.invited_by_user
+        assert_equal 'operator', invite.role
+        assert_equal 'pending', invite.status
+        assert invite.expires_at > Time.current
+        assert_match(/Приглашение создано/, flash[:notice])
+      end
+
+      test 'create with admin role creates admin invite' do
+        assert_difference -> { TenantInvite.count }, 1 do
+          post admin_tenant_invites_path(@tenant), params: {
+            tenant_invite: { role: 'admin' }
+          }
+        end
+
+        invite = TenantInvite.last
+        assert_equal 'admin', invite.role
+      end
+
+      test 'create with viewer role creates viewer invite' do
+        assert_difference -> { TenantInvite.count }, 1 do
+          post admin_tenant_invites_path(@tenant), params: {
+            tenant_invite: { role: 'viewer' }
+          }
+        end
+
+        invite = TenantInvite.last
+        assert_equal 'viewer', invite.role
+      end
+
+      test 'destroy cancels invite' do
+        invite = TenantInvite.create!(
+          tenant: @tenant,
+          invited_by_admin: @admin_user,
+          role: :operator,
+          expires_at: 7.days.from_now
+        )
+
+        delete admin_tenant_invite_path(@tenant, invite)
+
+        assert_redirected_to [ :admin, @tenant ]
+        invite.reload
+        assert invite.cancelled?
+        assert_not_nil invite.cancelled_at
+        assert_match(/Приглашение отменено/, flash[:notice])
+      end
+
+      test 'requires authentication' do
+        sign_out_admin
+
+        post admin_tenant_invites_path(@tenant), params: {
+          tenant_invite: { role: 'operator' }
+        }
+
+        assert_response :redirect
+        assert_redirected_to admin_login_path
+      end
+
+      private
+
+      def sign_in_admin(admin_user)
+        post admin_login_path, params: {
+          email: admin_user.email,
+          password: 'password'
+        }
+      end
+
+      def sign_out_admin
+        delete admin_logout_path
+      end
+    end
+  end
+end

--- a/test/fixtures/tenant_invites.yml
+++ b/test/fixtures/tenant_invites.yml
@@ -2,7 +2,7 @@
 
 pending_invite:
   tenant: one
-  invited_by: one
+  invited_by_user: one
   token: MBR_pending_test_token
   role: 1
   status: 0
@@ -10,7 +10,7 @@ pending_invite:
 
 accepted_invite:
   tenant: one
-  invited_by: one
+  invited_by_user: one
   accepted_by: two
   token: MBR_accepted_test_token
   role: 1
@@ -20,7 +20,7 @@ accepted_invite:
 
 expired_invite:
   tenant: one
-  invited_by: one
+  invited_by_user: one
   token: MBR_expired_test_token
   role: 0
   status: 0
@@ -28,9 +28,17 @@ expired_invite:
 
 cancelled_invite:
   tenant: two
-  invited_by: two
+  invited_by_user: two
   token: MBR_cancelled_test_token
   role: 2
   status: 3
   expires_at: <%= 7.days.from_now.to_fs(:db) %>
   cancelled_at: <%= 1.day.ago.to_fs(:db) %>
+
+admin_pending_invite:
+  tenant: one
+  invited_by_admin: superuser
+  token: MBR_admin_pending_token
+  role: 2
+  status: 0
+  expires_at: <%= 7.days.from_now.to_fs(:db) %>


### PR DESCRIPTION
## Summary

- Adds ability for admin managers to invite tenant owners and employees directly from the admin panel
- Restructures `TenantInvite` model: renames `invited_by_id` → `invited_by_user_id` and adds `invited_by_admin_id`
- Adds invite section on tenant show page with role selector (viewer, operator, admin)
- Displays active invites with Telegram links and copy functionality
- Allows canceling pending invites

Closes #86

## Changes

- **Migration**: Rename `invited_by_id` to `invited_by_user_id`, add `invited_by_admin_id` with FK to `admin_users`
- **Model**: Updated `TenantInvite` with dual belongs_to and validation for at least one inviter
- **Controller**: New `Admin::Tenants::InvitesController` for create/destroy actions
- **Views**: New `_invites_section.html.erb` partial rendered on tenant show page
- **Routes**: Nested invites resource under tenants
- **Tests**: Full coverage for new controller and updated model tests

## Test plan

- [x] All 378 tests pass
- [x] RuboCop passes
- [x] Brakeman passes (with ignore for false positive on `:role` param)
- [ ] Manual test: Create invite from admin tenant page
- [ ] Manual test: Copy Telegram link
- [ ] Manual test: Cancel invite

🤖 Generated with [Claude Code](https://claude.com/claude-code)