### PR TITLE
feat(session): Share session cookie across all subdomains

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -47,6 +47,9 @@ module Valera
     # For '3010.brandymint.ru' -> tld_length=2 -> subdomain 'admin' (not 'admin.3010')
     config.action_dispatch.tld_length = ApplicationConfig.tld_length
 
+    # Session cookie shared across all subdomains
+    config.session_store :cookie_store, key: '_session', domain: :all
+
     # Configure default URL options for route helpers and mailers
     Rails.application.routes.default_url_options = ApplicationConfig.default_url_options
   end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -103,10 +103,6 @@ Rails.application.configure do
   # Rate limiting configuration
   config.action_dispatch.rescue_responses['ActionController::RoutingError'] = :not_found
 
-  # Production-specific performance optimizations
-  config.middleware.use ActionDispatch::Cookies
-  config.middleware.use ActionDispatch::Session::CookieStore
-
   # Enable detailed error logging for monitoring
   config.log_level = ENV.fetch('RAILS_LOG_LEVEL', 'info')
 


### PR DESCRIPTION
## Summary

- Добавлен `config.session_store` с `domain: :all` в `application.rb`
- Удалены избыточные явные middleware из `production.rb`
- Изменён ключ сессии с `_valera_session` на `_session` для избежания конфликтов со старыми куками

## Проблема

Ранее cookie сессии вешалась на точный домен (`demo.supervalera.ru`), поэтому при переходе на другой субдомен (`tenant2.supervalera.ru`) пользователь терял авторизацию.

## Решение

Теперь cookie вешается на главный домен (`.supervalera.ru`) и работает на всех субдоменах.

## Безопасность

`current_membership` по-прежнему проверяет принадлежность пользователя к tenant — shared session не даёт cross-tenant доступ.

## Test plan

- [x] `bin/rails test` — 427 тестов проходят
- [ ] Локально: авторизоваться на `demo.lvh.me:3000`, перейти на `tenant2.lvh.me:3000` — должен остаться залогинен
- [ ] Проверить что доступ к tenant по-прежнему требует membership

🤖 Generated with [Claude Code](https://claude.com/claude-code)