### PR TITLE
feat(tenant): Расширенные настройки с вкладками и управлением webhook (#105)

### DIFF
--- a/app/controllers/tenants/settings_controller.rb
+++ b/app/controllers/tenants/settings_controller.rb
@@ -2,44 +2,77 @@
 
 module Tenants
   # Settings controller for tenant dashboard.
-  # Allows admin to edit tenant settings like key (subdomain).
+  # Allows admin to edit tenant settings: subdomain, Telegram config, and content.
   #
   class SettingsController < ApplicationController
     before_action :require_admin!
+    before_action :set_tenant
 
     # GET /settings/edit
     def edit
-      @tenant = current_tenant
+      load_webhook_status
     end
 
     # PATCH /settings
     def update
-      @tenant = current_tenant
       old_key = @tenant.key
 
       if @tenant.update(tenant_params)
-        if @tenant.key != old_key
-          redirect_to_new_subdomain
-        else
-          redirect_to edit_tenant_settings_path, notice: t('.success')
-        end
+        handle_successful_update(old_key)
       else
+        load_webhook_status
         render :edit, status: :unprocessable_entity
       end
     end
 
     private
 
-    def tenant_params
-      params.require(:tenant).permit(:key)
+    def set_tenant
+      @tenant = current_tenant
     end
 
-    # Redirect to new subdomain after key change
+    def tenant_params
+      params.require(:tenant).permit(
+        :key,
+        :new_bot_token,
+        :admin_chat_id,
+        :welcome_message,
+        :company_info,
+        :price_list
+      )
+    end
+
+    def handle_successful_update(old_key)
+      if @tenant.key != old_key
+        redirect_to_new_subdomain
+      else
+        redirect_to edit_tenant_settings_path(anchor: params[:active_tab]),
+                    notice: t('.success')
+      end
+    end
+
     def redirect_to_new_subdomain
       new_host = "#{@tenant.key}.#{ApplicationConfig.host}"
       new_url = "#{request.protocol}#{new_host}:#{request.port}#{edit_tenant_settings_path}"
 
       redirect_to new_url, notice: t('.key_changed'), allow_other_host: true
+    end
+
+    def load_webhook_status
+      return unless @tenant.bot_token.present?
+
+      @webhook_info = TenantWebhookService.new(@tenant).webhook_info
+      @expected_url = @tenant.webhook_url
+      @current_url = @webhook_info.dig('result', 'url')
+      @webhook_status = determine_webhook_status
+    rescue TenantWebhookService::TelegramApiError, Telegram::Bot::Error => e
+      @webhook_error = e.message
+    end
+
+    def determine_webhook_status
+      return :not_set if @current_url.blank?
+
+      @current_url == @expected_url ? :correct : :mismatch
     end
   end
 end

--- a/app/controllers/tenants/webhooks_controller.rb
+++ b/app/controllers/tenants/webhooks_controller.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module Tenants
+  # Controller for managing Telegram webhook from tenant dashboard.
+  # Allows admin to setup, remove, and check webhook status.
+  #
+  class WebhooksController < ApplicationController
+    before_action :require_admin!
+
+    # POST /webhook
+    # Setup webhook in Telegram
+    def create
+      TenantWebhookService.new(current_tenant).setup_webhook
+
+      redirect_to edit_tenant_settings_path(anchor: 'telegram'),
+                  notice: t('.success')
+    rescue TenantWebhookService::TelegramApiError => e
+      redirect_to edit_tenant_settings_path(anchor: 'telegram'),
+                  alert: t('.error', message: e.message)
+    end
+
+    # DELETE /webhook
+    # Remove webhook from Telegram
+    def destroy
+      TenantWebhookService.new(current_tenant).remove_webhook
+
+      redirect_to edit_tenant_settings_path(anchor: 'telegram'),
+                  notice: t('.success')
+    rescue TenantWebhookService::TelegramApiError => e
+      redirect_to edit_tenant_settings_path(anchor: 'telegram'),
+                  alert: t('.error', message: e.message)
+    end
+  end
+end

--- a/app/helpers/tenants_helper.rb
+++ b/app/helpers/tenants_helper.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+# Helper methods for tenant dashboard views
+module TenantsHelper
+  # Masks bot token for secure display
+  # Shows bot_id and first/last 2 characters of secret
+  #
+  # @param token [String] Telegram bot token (e.g., "123456789:ABCdefGHI...")
+  # @return [String, nil] Masked token (e.g., "123456789:AB...HI") or nil if blank
+  #
+  # @example
+  #   masked_bot_token("123456789:ABCdefGHIjklMNO")
+  #   # => "123456789:AB...NO"
+  #
+  def masked_bot_token(token)
+    return nil if token.blank?
+
+    parts = token.split(':')
+    return token if parts.length < 2 || parts[1].length < 4
+
+    bot_id = parts[0]
+    secret = parts[1]
+    "#{bot_id}:#{secret[0..1]}...#{secret[-2..]}"
+  end
+end

--- a/app/views/tenants/settings/_webhook_status.html.slim
+++ b/app/views/tenants/settings/_webhook_status.html.slim
@@ -1,0 +1,81 @@
+/ Webhook status partial for tenant settings
+/ Displays current webhook state and management buttons
+
+h3.text-md.font-medium.text-gray-700.mb-3 Webhook
+
+- if @webhook_error
+  / Error state
+  .p-4.bg-red-50.border.border-red-200.rounded-lg
+    .flex.items-start.gap-3
+      span.text-red-500 ⚠️
+      div
+        p.text-sm.font-medium.text-red-800 Ошибка получения статуса webhook
+        p.text-sm.text-red-600.mt-1
+          = @webhook_error
+
+- elsif @tenant.bot_token.blank?
+  / No bot token configured
+  .p-4.bg-gray-50.border.border-gray-200.rounded-lg
+    p.text-sm.text-gray-600
+      | Для настройки webhook сначала укажите Bot Token.
+
+- elsif @webhook_status == :not_set
+  / Webhook not configured
+  .p-4.bg-amber-50.border.border-amber-200.rounded-lg
+    .flex.items-start.gap-3
+      span.text-amber-500 ⚠️
+      div
+        p.text-sm.font-medium.text-amber-800 Webhook не установлен
+        p.text-sm.text-amber-600.mt-1
+          | Бот не будет получать сообщения от пользователей.
+        .mt-3
+          = button_to 'Установить webhook', tenant_webhook_path, \
+            method: :post, \
+            class: 'px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white text-sm font-medium rounded-lg transition duration-200'
+
+- elsif @webhook_status == :correct
+  / Webhook correctly configured
+  .p-4.bg-green-50.border.border-green-200.rounded-lg
+    .flex.items-start.gap-3
+      span.text-green-500 ✅
+      div
+        p.text-sm.font-medium.text-green-800 Webhook установлен
+        dl.mt-2.text-sm
+          .flex.gap-2
+            dt.text-gray-600 URL:
+            dd.font-mono.text-gray-800.break-all
+              = @current_url
+          - if @webhook_info.dig('result', 'pending_update_count')
+            .flex.gap-2.mt-1
+              dt.text-gray-600 Pending updates:
+              dd.text-gray-800
+                = @webhook_info.dig('result', 'pending_update_count')
+        .mt-3.flex.gap-2
+          = button_to 'Переустановить', tenant_webhook_path, \
+            method: :post, \
+            class: 'px-3 py-1.5 bg-gray-600 hover:bg-gray-700 text-white text-sm font-medium rounded-lg transition duration-200'
+          = button_to 'Удалить', tenant_webhook_path, \
+            method: :delete, \
+            class: 'px-3 py-1.5 bg-red-600 hover:bg-red-700 text-white text-sm font-medium rounded-lg transition duration-200', \
+            data: { turbo_confirm: 'Вы уверены? Бот перестанет получать сообщения.' }
+
+- elsif @webhook_status == :mismatch
+  / Webhook configured but URL mismatch
+  .p-4.bg-amber-50.border.border-amber-200.rounded-lg
+    .flex.items-start.gap-3
+      span.text-amber-500 ⚠️
+      div
+        p.text-sm.font-medium.text-amber-800 Webhook URL не совпадает
+        dl.mt-2.text-sm
+          .flex.gap-2
+            dt.text-gray-600 Текущий:
+            dd.font-mono.text-gray-800.break-all
+              = @current_url
+          .flex.gap-2.mt-1
+            dt.text-gray-600 Ожидаемый:
+            dd.font-mono.text-gray-800.break-all
+              = @expected_url
+        .mt-3
+          = button_to 'Переустановить webhook', tenant_webhook_path, \
+            method: :post, \
+            class: 'px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white text-sm font-medium rounded-lg transition duration-200'

--- a/app/views/tenants/settings/edit.html.slim
+++ b/app/views/tenants/settings/edit.html.slim
@@ -1,45 +1,155 @@
 h1.text-2xl.font-bold.text-gray-800.mb-6 Настройки
 
-.max-w-2xl
-  .bg-white.rounded-lg.shadow.p-6
-    h2.text-lg.font-semibold.text-gray-700.mb-4 Поддомен
-
+.max-w-4xl
+  div data-controller="admin-tabs" class="admin-tabs-container admin-tabs--loading"
     = form_with model: @tenant, url: tenant_settings_path, method: :patch, class: "space-y-4" do |f|
+      / Hidden field to track active tab
+      = hidden_field_tag :active_tab, nil, id: 'active_tab_field', data: { admin_tabs_target: 'activeTabField' }
+
+      / Error messages
       - if @tenant.errors.any?
         .p-4.bg-red-100.border.border-red-400.text-red-700.rounded.text-sm.mb-4
           ul.list-disc.list-inside
             - @tenant.errors.full_messages.each do |msg|
               li = msg
 
-      div
-        label.block.text-sm.font-medium.text-gray-700.mb-1 for="tenant_key"
-          | Ключ (поддомен)
-        .flex.items-center.gap-2
-          = f.text_field :key, \
-            class: "flex-1 px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500 font-mono", \
-            placeholder: "example", \
-            minlength: 3, \
-            maxlength: 64, \
-            pattern: "[a-z0-9]+", \
-            required: true
-          span.text-gray-500
-            = ".#{ApplicationConfig.host}"
+      .admin-tabs.bg-white.rounded-lg.shadow
+        / Tab navigation
+        .admin-tabs__nav.px-6.pt-4
+          button.admin-tabs__button.admin-tabs__button--active type="button" \
+            data-admin-tabs-target="tab" data-action="click->admin-tabs#switch" \
+            data-index="0" data-slug="osnovnoe"
+            | Основное
+          button.admin-tabs__button type="button" \
+            data-admin-tabs-target="tab" data-action="click->admin-tabs#switch" \
+            data-index="1" data-slug="telegram"
+            | Telegram
+          button.admin-tabs__button type="button" \
+            data-admin-tabs-target="tab" data-action="click->admin-tabs#switch" \
+            data-index="2" data-slug="content"
+            | Контент
 
-        p.text-sm.text-gray-500.mt-1
-          | Ключ должен содержать от 3 до 64 символов: только строчные латинские буквы и цифры.
-        p.text-sm.text-amber-600.mt-1
-          | После изменения вы будете перенаправлены на новый адрес.
+        / Tab panels
+        .p-6
 
-      .pt-4
-        button.px-4.py-2.bg-blue-600.hover:bg-blue-700.text-white.font-semibold.rounded-lg.transition.duration-200[
-          type="submit"
-        ]
-          | Сохранить
+          / === Tab 1: Основное ===
+          fieldset.admin-tabs__panel data-admin-tabs-target="panel"
+            .space-y-6
 
-    .mt-6.pt-6.border-t.border-gray-200
-      h3.text-md.font-medium.text-gray-700.mb-2 Текущий адрес панели управления
-      .flex.items-center.gap-2
-        code.px-3.py-2.bg-gray-100.rounded.text-sm.font-mono
-          = @tenant.dashboard_url
-        = link_to @tenant.dashboard_url, target: "_blank", class: "text-blue-600 hover:text-blue-800 text-sm"
-          | Открыть
+              / Subdomain field
+              div
+                label.block.text-sm.font-medium.text-gray-700.mb-1 for="tenant_key"
+                  | Поддомен
+                .flex.items-center.gap-2
+                  = f.text_field :key, \
+                    class: "flex-1 px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500 font-mono", \
+                    placeholder: "example", \
+                    minlength: 3, \
+                    maxlength: 64, \
+                    pattern: "[a-z0-9]+", \
+                    required: true
+                  span.text-gray-500
+                    = ".#{ApplicationConfig.host}"
+                p.text-sm.text-gray-500.mt-1
+                  | Ключ должен содержать от 3 до 64 символов: только строчные латинские буквы и цифры.
+                p.text-sm.text-amber-600.mt-1
+                  | После изменения вы будете перенаправлены на новый адрес.
+
+              / Current dashboard URL
+              .pt-4.border-t.border-gray-200
+                h3.text-md.font-medium.text-gray-700.mb-2 Текущий адрес панели управления
+                .flex.items-center.gap-2
+                  code.px-3.py-2.bg-gray-100.rounded.text-sm.font-mono
+                    = @tenant.dashboard_url
+                  = link_to @tenant.dashboard_url, target: "_blank", class: "text-blue-600 hover:text-blue-800 text-sm"
+                    | Открыть
+
+          / === Tab 2: Telegram ===
+          fieldset.admin-tabs__panel data-admin-tabs-target="panel" hidden=true
+            .space-y-6
+
+              / Bot Token field
+              div
+                label.block.text-sm.font-medium.text-gray-700.mb-1 for="tenant_new_bot_token"
+                  | Bot Token
+                - if @tenant.bot_token.present?
+                  .mb-2
+                    span.text-sm.text-gray-600.mr-2 Текущий:
+                    code.px-2.py-1.bg-gray-100.rounded.text-sm.font-mono
+                      = masked_bot_token(@tenant.bot_token)
+                = f.text_field :new_bot_token, \
+                  value: '', \
+                  class: "w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500 font-mono", \
+                  placeholder: @tenant.bot_token.present? ? 'Новый токен (оставьте пустым для сохранения текущего)' : 'Введите токен бота', \
+                  autocomplete: 'off'
+                p.text-sm.text-gray-500.mt-1
+                  | Получите токен у
+                  = link_to '@BotFather', 'https://t.me/BotFather', target: '_blank', class: 'text-blue-600 hover:text-blue-800'
+                  |  в Telegram.
+
+              / Admin Chat ID field
+              div
+                label.block.text-sm.font-medium.text-gray-700.mb-1 for="tenant_admin_chat_id"
+                  | Admin Chat ID
+                = f.number_field :admin_chat_id, \
+                  class: "w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500 font-mono", \
+                  placeholder: 'Например: 123456789'
+                p.text-sm.text-gray-500.mt-1
+                  | Chat ID для получения уведомлений о новых заявках. Узнать можно через
+                  = link_to '@userinfobot', 'https://t.me/userinfobot', target: '_blank', class: 'text-blue-600 hover:text-blue-800'
+                  | .
+
+              / Webhook status
+              .pt-4.border-t.border-gray-200
+                = render 'tenants/settings/webhook_status'
+
+          / === Tab 3: Контент ===
+          fieldset.admin-tabs__panel data-admin-tabs-target="panel" hidden=true
+            .space-y-6
+
+              / Welcome message field
+              div
+                label.block.text-sm.font-medium.text-gray-700.mb-1 for="tenant_welcome_message"
+                  | Приветственное сообщение
+                = f.text_area :welcome_message, \
+                  class: "w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500", \
+                  rows: 6, \
+                  placeholder: @tenant.welcome_message_or_default
+                p.text-sm.text-gray-500.mt-1
+                  | Первое сообщение при старте диалога. Поддерживает Markdown.
+                - if @tenant.welcome_message.blank?
+                  p.text-sm.text-blue-600.mt-1
+                    | Если оставить пустым — используется значение по умолчанию.
+
+              / Company info field
+              div
+                label.block.text-sm.font-medium.text-gray-700.mb-1 for="tenant_company_info"
+                  | Информация о компании
+                = f.text_area :company_info, \
+                  class: "w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500", \
+                  rows: 10, \
+                  placeholder: @tenant.company_info_or_default
+                p.text-sm.text-gray-500.mt-1
+                  | Название, адрес, телефон, email, время работы — всё что AI должен знать о компании.
+                - if @tenant.company_info.blank?
+                  p.text-sm.text-blue-600.mt-1
+                    | Если оставить пустым — используется значение по умолчанию.
+
+              / Price list field
+              div
+                label.block.text-sm.font-medium.text-gray-700.mb-1 for="tenant_price_list"
+                  | Прайс-лист
+                = f.text_area :price_list, \
+                  class: "w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500 font-mono text-sm", \
+                  rows: 15, \
+                  placeholder: @tenant.price_list_or_default
+                p.text-sm.text-gray-500.mt-1
+                  | CSV формат: услуга, цена по классам авто. AI использует для расчёта стоимости.
+                - if @tenant.price_list.blank?
+                  p.text-sm.text-blue-600.mt-1
+                    | Если оставить пустым — используется значение по умолчанию.
+
+        / Submit button
+        .px-6.pb-6.pt-2.border-t.border-gray-200
+          button.px-6.py-2.bg-blue-600.hover:bg-blue-700.text-white.font-semibold.rounded-lg.transition.duration-200 type="submit"
+            | Сохранить

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -381,6 +381,13 @@ ru:
       update:
         success: Настройки сохранены
         key_changed: Поддомен изменён. Вы перенаправлены на новый адрес.
+    webhooks:
+      create:
+        success: Webhook успешно установлен
+        error: "Ошибка установки webhook: %{message}"
+      destroy:
+        success: Webhook удалён
+        error: "Ошибка удаления webhook: %{message}"
     clients:
       index:
         title: Клиенты

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -72,6 +72,7 @@ Rails.application.routes.draw do
         end
       end
       resource :settings, only: %i[edit update]
+      resource :webhook, only: %i[create destroy]
     end
   end
 

--- a/test/controllers/tenants/settings_controller_test.rb
+++ b/test/controllers/tenants/settings_controller_test.rb
@@ -8,6 +8,10 @@ module Tenants
       @tenant = tenants(:one)
       @owner = @tenant.owner
       @owner.update!(password: 'password123')
+
+      # Mock Telegram API for webhook status check
+      mock_webhook_info = { 'ok' => true, 'result' => { 'url' => @tenant.webhook_url } }
+      TenantWebhookService.any_instance.stubs(:webhook_info).returns(mock_webhook_info)
     end
 
     test 'redirects to login when not authenticated' do
@@ -17,7 +21,7 @@ module Tenants
       assert_redirected_to '/session/new'
     end
 
-    test 'shows settings form when authenticated as owner' do
+    test 'shows settings form with tabs when authenticated as owner' do
       host! "#{@tenant.key}.#{ApplicationConfig.host}"
       post '/session', params: { email: @owner.email, password: 'password123' }
 
@@ -25,6 +29,9 @@ module Tenants
 
       assert_response :success
       assert_select 'h1', /Настройки/
+      # Check tabs are present (3 tabs total)
+      assert_select 'button.admin-tabs__button', count: 3
+      # Check key field is present
       assert_select "input[name='tenant[key]']"
     end
 
@@ -98,6 +105,101 @@ module Tenants
 
       assert_response :success
       assert_select 'code', /#{@tenant.key}/
+    end
+
+    test 'updates admin_chat_id successfully' do
+      host! "#{@tenant.key}.#{ApplicationConfig.host}"
+      post '/session', params: { email: @owner.email, password: 'password123' }
+
+      patch '/settings', params: { tenant: { admin_chat_id: 123_456_789 } }
+
+      @tenant.reload
+      assert_equal 123_456_789, @tenant.admin_chat_id
+      assert_response :redirect
+    end
+
+    test 'updates welcome_message successfully' do
+      host! "#{@tenant.key}.#{ApplicationConfig.host}"
+      post '/session', params: { email: @owner.email, password: 'password123' }
+
+      new_message = 'Добро пожаловать в наш автосервис!'
+      patch '/settings', params: { tenant: { welcome_message: new_message } }
+
+      @tenant.reload
+      assert_equal new_message, @tenant.welcome_message
+      assert_response :redirect
+    end
+
+    test 'updates company_info successfully' do
+      host! "#{@tenant.key}.#{ApplicationConfig.host}"
+      post '/session', params: { email: @owner.email, password: 'password123' }
+
+      new_info = "ООО Автосервис\nТел: +7 999 123-45-67"
+      patch '/settings', params: { tenant: { company_info: new_info } }
+
+      @tenant.reload
+      assert_equal new_info, @tenant.company_info
+      assert_response :redirect
+    end
+
+    test 'updates price_list successfully' do
+      host! "#{@tenant.key}.#{ApplicationConfig.host}"
+      post '/session', params: { email: @owner.email, password: 'password123' }
+
+      new_price_list = 'Покраска бампера,5000,7000,10000'
+      patch '/settings', params: { tenant: { price_list: new_price_list } }
+
+      @tenant.reload
+      assert_equal new_price_list, @tenant.price_list
+      assert_response :redirect
+    end
+
+    test 'updates bot_token via new_bot_token' do
+      host! "#{@tenant.key}.#{ApplicationConfig.host}"
+      post '/session', params: { email: @owner.email, password: 'password123' }
+
+      # Mock Telegram API call for bot username fetch
+      TenantWebhookService.any_instance.stubs(:webhook_info).returns({ 'ok' => true, 'result' => {} })
+      Telegram::Bot::Client.any_instance.stubs(:get_me).returns({
+        'ok' => true,
+        'result' => { 'username' => 'new_test_bot' }
+      })
+
+      new_token = '999999999:BBBnewtoken123456789'
+      patch '/settings', params: { tenant: { new_bot_token: new_token } }
+
+      @tenant.reload
+      assert_equal new_token, @tenant.bot_token
+      assert_equal 'new_test_bot', @tenant.bot_username
+    end
+
+    test 'shows telegram fields in form' do
+      host! "#{@tenant.key}.#{ApplicationConfig.host}"
+      post '/session', params: { email: @owner.email, password: 'password123' }
+
+      # Mock Telegram API for webhook status
+      TenantWebhookService.any_instance.stubs(:webhook_info).returns({ 'ok' => true, 'result' => {} })
+
+      get '/settings/edit'
+
+      assert_response :success
+      assert_select "input[name='tenant[new_bot_token]']"
+      assert_select "input[name='tenant[admin_chat_id]']"
+    end
+
+    test 'shows content fields in form' do
+      host! "#{@tenant.key}.#{ApplicationConfig.host}"
+      post '/session', params: { email: @owner.email, password: 'password123' }
+
+      # Mock Telegram API for webhook status
+      TenantWebhookService.any_instance.stubs(:webhook_info).returns({ 'ok' => true, 'result' => {} })
+
+      get '/settings/edit'
+
+      assert_response :success
+      assert_select "textarea[name='tenant[welcome_message]']"
+      assert_select "textarea[name='tenant[company_info]']"
+      assert_select "textarea[name='tenant[price_list]']"
     end
   end
 end

--- a/test/controllers/tenants/webhooks_controller_test.rb
+++ b/test/controllers/tenants/webhooks_controller_test.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module Tenants
+  class WebhooksControllerTest < ActionDispatch::IntegrationTest
+    setup do
+      @tenant = tenants(:one)
+      @owner = @tenant.owner
+      @owner.update!(password: 'password123')
+
+      host! "#{@tenant.key}.#{ApplicationConfig.host}"
+      post '/session', params: { email: @owner.email, password: 'password123' }
+    end
+
+    test 'creates webhook successfully' do
+      TenantWebhookService.any_instance.expects(:setup_webhook).returns({ 'ok' => true })
+
+      post '/webhook'
+
+      assert_redirected_to '/settings/edit#telegram'
+      assert_equal I18n.t('tenants.webhooks.create.success'), flash[:notice]
+    end
+
+    test 'shows error when webhook creation fails' do
+      TenantWebhookService.any_instance.expects(:setup_webhook)
+        .raises(TenantWebhookService::TelegramApiError.new('API Error'))
+
+      post '/webhook'
+
+      assert_redirected_to '/settings/edit#telegram'
+      assert_match(/API Error/, flash[:alert])
+    end
+
+    test 'destroys webhook successfully' do
+      TenantWebhookService.any_instance.expects(:remove_webhook).returns({ 'ok' => true })
+
+      delete '/webhook'
+
+      assert_redirected_to '/settings/edit#telegram'
+      assert_equal I18n.t('tenants.webhooks.destroy.success'), flash[:notice]
+    end
+
+    test 'shows error when webhook deletion fails' do
+      TenantWebhookService.any_instance.expects(:remove_webhook)
+        .raises(TenantWebhookService::TelegramApiError.new('Delete Error'))
+
+      delete '/webhook'
+
+      assert_redirected_to '/settings/edit#telegram'
+      assert_match(/Delete Error/, flash[:alert])
+    end
+
+    test 'requires admin access' do
+      # Logout
+      delete '/session'
+
+      post '/webhook'
+      assert_redirected_to '/session/new'
+
+      delete '/webhook'
+      assert_redirected_to '/session/new'
+    end
+  end
+end

--- a/test/helpers/tenants_helper_test.rb
+++ b/test/helpers/tenants_helper_test.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class TenantsHelperTest < ActionView::TestCase
+  include TenantsHelper
+
+  test 'masked_bot_token returns nil for blank token' do
+    assert_nil masked_bot_token(nil)
+    assert_nil masked_bot_token('')
+  end
+
+  test 'masked_bot_token returns original for invalid format' do
+    assert_equal 'invalid', masked_bot_token('invalid')
+    assert_equal '123:ab', masked_bot_token('123:ab')
+  end
+
+  test 'masked_bot_token masks token correctly' do
+    token = '123456789:ABCdefGHIjklMNOpqrs'
+    result = masked_bot_token(token)
+
+    assert_equal '123456789:AB...rs', result
+  end
+
+  test 'masked_bot_token works with short secrets' do
+    token = '123:abcd'
+    result = masked_bot_token(token)
+
+    assert_equal '123:ab...cd', result
+  end
+end


### PR DESCRIPTION
## Summary
- Добавлены три вкладки в настройках: **Основное**, **Telegram**, **Контент**
- Owner и Admin теперь могут редактировать: bot_token, admin_chat_id, welcome_message, company_info, price_list
- Добавлен WebhooksController для управления Telegram webhook (установка/удаление)
- Статус webhook отображается с кнопками управления
- Helper `masked_bot_token` для безопасного отображения токена

## Changes
- `app/controllers/tenants/settings_controller.rb` - расширены permitted params, загрузка статуса webhook
- `app/controllers/tenants/webhooks_controller.rb` - NEW: управление webhook
- `app/helpers/tenants_helper.rb` - NEW: masked_bot_token helper
- `app/views/tenants/settings/edit.html.slim` - переписан с вкладками (Stimulus tabs)
- `app/views/tenants/settings/_webhook_status.html.slim` - NEW: статус webhook
- `config/routes.rb` - добавлен route для webhook
- `config/locales/ru.yml` - локализации для webhook

## Test plan
- [x] Тесты для SettingsController (19 тестов)
- [x] Тесты для WebhooksController (5 тестов)
- [x] Тесты для TenantsHelper (4 теста)
- [x] CI проходит (443 теста, 0 failures)

Closes #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)