### PR TITLE
Add LLM costs UI to dashboard

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -24,4 +24,21 @@ module ApplicationHelper
 
     time_ago_in_words(time, include_seconds: false)
   end
+
+  # Форматирует стоимость в долларах
+  # format_cost(0.123456) => "$0.12"
+  # format_cost(1.5) => "$1.50"
+  def format_cost(amount)
+    return '$0.00' if amount.nil? || amount.zero?
+
+    "$#{format('%.2f', amount)}"
+  end
+
+  # Форматирует количество токенов с разделителями тысяч
+  # format_tokens(1234567) => "1,234,567"
+  def format_tokens(count)
+    return '0' if count.nil? || count.zero?
+
+    number_with_delimiter(count)
+  end
 end

--- a/app/javascript/controllers/cost_chart_controller.js
+++ b/app/javascript/controllers/cost_chart_controller.js
@@ -1,0 +1,67 @@
+import { Controller } from "@hotwired/stimulus"
+import Chart from "chart.js/auto"
+
+// Контроллер для отображения графика расходов на LLM
+// Использует Chart.js для рендеринга bar chart
+export default class extends Controller {
+  static targets = ["canvas"]
+
+  connect() {
+    const labels = JSON.parse(this.canvasTarget.dataset.costChartLabels)
+    const values = JSON.parse(this.canvasTarget.dataset.costChartValues)
+
+    this.chart = new Chart(this.canvasTarget, {
+      type: "bar",
+      data: {
+        labels,
+        datasets: [{
+          label: "Расходы ($)",
+          data: values,
+          backgroundColor: "rgba(34, 197, 94, 0.6)",
+          borderColor: "#22c55e",
+          borderWidth: 1,
+          borderRadius: 4
+        }]
+      },
+      options: {
+        responsive: true,
+        maintainAspectRatio: false,
+        plugins: {
+          legend: { display: false },
+          tooltip: {
+            backgroundColor: "#1f2937",
+            titleColor: "#f9fafb",
+            bodyColor: "#f9fafb",
+            padding: 12,
+            cornerRadius: 8,
+            callbacks: {
+              label: function(context) {
+                return `$${context.parsed.y.toFixed(4)}`
+              }
+            }
+          }
+        },
+        scales: {
+          y: {
+            beginAtZero: true,
+            grid: { color: "rgba(0, 0, 0, 0.05)" },
+            ticks: {
+              callback: function(value) {
+                return `$${value.toFixed(2)}`
+              }
+            }
+          },
+          x: {
+            grid: { display: false }
+          }
+        }
+      }
+    })
+  }
+
+  disconnect() {
+    if (this.chart) {
+      this.chart.destroy()
+    }
+  }
+}

--- a/app/services/dashboard_stats_service.rb
+++ b/app/services/dashboard_stats_service.rb
@@ -23,6 +23,7 @@ class DashboardStatsService
     :chart_data,
     :recent_chats,
     :funnel_data,
+    :llm_costs,
     keyword_init: true
   )
 
@@ -53,7 +54,8 @@ class DashboardStatsService
       messages_today: messages_today_count,
       chart_data: build_chart_data,
       recent_chats: fetch_recent_chats,
-      funnel_data: build_funnel_data
+      funnel_data: build_funnel_data,
+      llm_costs: build_llm_costs
     )
   end
 
@@ -138,6 +140,24 @@ class DashboardStatsService
       chats_count: chats_count,
       bookings_count: bookings_count,
       conversion_rate: conversion_rate
+    }
+  end
+
+  def build_llm_costs
+    calculator = LlmCostCalculator.new(tenant, period: effective_chart_period)
+
+    totals = calculator.calculate_totals
+    by_model = calculator.calculate_by_model
+    by_day = calculator.calculate_by_day
+
+    {
+      totals: totals,
+      by_model: by_model,
+      by_day: by_day,
+      chart_data: {
+        labels: by_day.map { |d| d.date.strftime('%d.%m') },
+        values: by_day.map { |d| d.total_cost.round(4) }
+      }
     }
   end
 end

--- a/app/views/tenants/home/show.html.slim
+++ b/app/views/tenants/home/show.html.slim
@@ -80,6 +80,64 @@ h1.text-2xl.font-bold.text-gray-800.mb-6 Обзор
             span.text-sm.font-medium.text-gray-600 Конверсия
             span.text-2xl.font-bold.text-green-600 #{@stats.funnel_data[:conversion_rate]}%
 
+  / Расходы на AI
+  .mt-8.bg-white.rounded-lg.shadow.p-6
+    h2.text-lg.font-semibold.text-gray-800.mb-4 💰 Расходы на AI
+
+    - totals = @stats.llm_costs[:totals]
+    - by_model = @stats.llm_costs[:by_model]
+
+    .grid.grid-cols-1.lg:grid-cols-2.gap-6
+      / Общая статистика токенов
+      div
+        .space-y-3
+          / Input tokens
+          .flex.items-center.justify-between.py-2.border-b.border-gray-100
+            span.text-sm.text-gray-600 Input tokens
+            .text-right
+              span.font-medium.text-gray-800 = format_tokens(totals.input_tokens)
+              span.text-gray-400.ml-2 = format_cost(totals.input_cost)
+
+          / Output tokens
+          .flex.items-center.justify-between.py-2.border-b.border-gray-100
+            span.text-sm.text-gray-600 Output tokens
+            .text-right
+              span.font-medium.text-gray-800 = format_tokens(totals.output_tokens)
+              span.text-gray-400.ml-2 = format_cost(totals.output_cost)
+
+          / Итого
+          .flex.items-center.justify-between.py-2.bg-gray-50.rounded-lg.px-3
+            span.text-sm.font-medium.text-gray-700 Итого
+            .text-right
+              span.font-bold.text-gray-800 = format_tokens(totals.total_tokens)
+              span.text-lg.font-bold.text-green-600.ml-2 = format_cost(totals.total_cost)
+
+      / Breakdown по моделям
+      div
+        - if by_model.any?
+          h3.text-sm.font-medium.text-gray-500.mb-3 По моделям:
+          .space-y-2
+            - by_model.each do |model_stats|
+              - percentage = totals.total_cost.positive? ? (model_stats.total_cost / totals.total_cost * 100).round(1) : 0
+              .flex.items-center.justify-between.py-2
+                .flex.items-center.gap-2
+                  span.text-sm.text-gray-700 = model_stats.model_name || model_stats.model_id
+                  span.text-xs.text-gray-400 = model_stats.provider
+                .text-right
+                  span.font-medium.text-gray-800 = format_cost(model_stats.total_cost)
+                  span.text-xs.text-gray-400.ml-1 = "(#{percentage}%)"
+        - else
+          .text-center.py-4
+            p.text-gray-500.text-sm Нет данных о расходах
+            p.text-xs.text-gray-400.mt-1 Расходы появятся после первых сообщений бота
+
+    / График расходов по дням
+    - if @stats.llm_costs[:chart_data][:values].any? { |v| v > 0 }
+      .mt-6.pt-6.border-t.border-gray-200 data-controller="cost-chart"
+        h3.text-sm.font-medium.text-gray-500.mb-3 График расходов
+        .h-48
+          canvas data-cost-chart-target="canvas" data-cost-chart-labels=@stats.llm_costs[:chart_data][:labels].to_json data-cost-chart-values=@stats.llm_costs[:chart_data][:values].to_json
+
   / Последние диалоги
   .mt-8.bg-white.rounded-lg.shadow.p-6
     h2.text-lg.font-semibold.text-gray-800.mb-4 🕐 Последние диалоги

--- a/test/controllers/tenants/home_controller_test.rb
+++ b/test/controllers/tenants/home_controller_test.rb
@@ -114,5 +114,25 @@ module Tenants
       assert_response :success
       assert_select 'turbo-frame#dashboard_stats'
     end
+
+    test 'shows LLM costs section' do
+      host! "#{@tenant.key}.#{ApplicationConfig.host}"
+      post '/session', params: { email: @owner.email, password: 'password123' }
+
+      get '/'
+
+      assert_response :success
+      assert_select 'h2', /Расходы на AI/
+    end
+
+    test 'shows conversion funnel section' do
+      host! "#{@tenant.key}.#{ApplicationConfig.host}"
+      post '/session', params: { email: @owner.email, password: 'password123' }
+
+      get '/'
+
+      assert_response :success
+      assert_select 'h2', /Воронка конверсии/
+    end
   end
 end


### PR DESCRIPTION
## Summary

- Интегрирован `LlmCostCalculator` в `DashboardStatsService`
- Добавлена секция расходов на AI с отображением токенов и стоимости
- Добавлен breakdown по моделям с процентным соотношением
- Добавлен bar chart для отображения расходов по дням

## Screenshot

```
┌─ 💰 Расходы на AI ─────────────────────┐
│                                         │
│  Input tokens:   45,230      $0.45     │
│  Output tokens:  12,456      $0.62     │
│  ─────────────────────────────────     │
│  Итого:          57,686      $1.07     │
│                                         │
│  По моделям:                            │
│  • claude-3-5-sonnet   $0.82 (77%)     │
│  • gpt-4o-mini         $0.25 (23%)     │
│                                         │
│  [График по дням]                       │
└─────────────────────────────────────────┘
```

## Changes

- `app/services/dashboard_stats_service.rb` - интеграция LlmCostCalculator
- `app/views/tenants/home/show.html.slim` - UI секция расходов на AI
- `app/javascript/controllers/cost_chart_controller.js` - Stimulus контроллер для графика
- `app/helpers/application_helper.rb` - хелперы format_cost и format_tokens

## Test plan

- [ ] Открыть dashboard тенанта
- [ ] Проверить отображение секции "Расходы на AI"
- [ ] Проверить что токены и стоимость отображаются корректно
- [ ] Проверить breakdown по моделям
- [ ] Проверить график расходов по дням (если есть данные)
- [ ] Переключить период и проверить что данные обновляются

Closes #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)