### PR TITLE
fix(chats): Remove unnecessary views_prefix from kaminari pagination

### DIFF
--- a/app/views/tenants/chats/_layout.html.slim
+++ b/app/views/tenants/chats/_layout.html.slim
@@ -18,7 +18,7 @@
       / Pagination
       - if @chats.total_pages > 1
         .p-2.border-t.border-gray-200.bg-gray-50
-          = paginate @chats, views_prefix: 'tenants/chats'
+          = paginate @chats
 
     / Chat messages (right panel)
     .flex-1.flex.flex-col.min-w-0


### PR DESCRIPTION
## Summary
- Исправлена ошибка `ActionView::MissingTemplate` на странице чатов
- Убран `views_prefix: 'tenants/chats'` из kaminari pagination
- Теперь используются стандартные шаблоны kaminari (как в bookings и clients)

## Problem
При открытии страницы `/chats/:id` возникала ошибка:
```
Missing partial tenants/chats/kaminari/_paginator
```

## Solution  
Убран ненужный `views_prefix` параметр. Другие views (bookings, clients) используют kaminari без `views_prefix` и работают корректно.

## Test plan
- [x] Открыть страницу чата `/chats/:id`
- [x] Убедиться что страница загружается без ошибок
- [x] Проверить что пагинация отображается и работает

🤖 Generated with [Claude Code](https://claude.com/claude-code)