### PR TITLE
fix(chat): Improve chat_scroll_controller reliability

### DIFF
--- a/app/javascript/controllers/chat_scroll_controller.js
+++ b/app/javascript/controllers/chat_scroll_controller.js
@@ -1,19 +1,33 @@
 import { Controller } from "@hotwired/stimulus"
 
 // Auto-scrolls chat to the bottom when connected
+// Attaches to the chat messages container and scrolls parent to show latest messages
 export default class extends Controller {
   connect() {
-    // Wait for DOM to be fully rendered before scrolling
-    requestAnimationFrame(() => {
+    // Store animation frame ID for cleanup
+    this.animationFrameId = requestAnimationFrame(() => {
       this.scrollToBottom()
     })
   }
 
+  disconnect() {
+    // Cancel pending animation frame to prevent memory leaks
+    if (this.animationFrameId) {
+      cancelAnimationFrame(this.animationFrameId)
+      this.animationFrameId = null
+    }
+  }
+
   scrollToBottom() {
     // Find the scrollable parent (the overflow-y-auto container)
-    const scrollableParent = this.element.closest('.overflow-y-auto')
-    if (scrollableParent) {
-      scrollableParent.scrollTop = scrollableParent.scrollHeight
+    const scrollableParent = this.element.closest('[data-scroll-container]') ||
+                             this.element.closest('.overflow-y-auto')
+
+    if (!scrollableParent) {
+      console.warn('chat_scroll_controller: scrollable parent not found')
+      return
     }
+
+    scrollableParent.scrollTop = scrollableParent.scrollHeight
   }
 }

--- a/app/views/tenants/chats/_layout.html.slim
+++ b/app/views/tenants/chats/_layout.html.slim
@@ -24,7 +24,7 @@
     .flex-1.flex.flex-col.min-w-0
       - if @chat
         = render 'chat_header', chat: @chat
-        .flex-1.overflow-y-auto.p-4.bg-gray-50
+        .flex-1.overflow-y-auto.p-4.bg-gray-50 data-scroll-container="true"
           = render 'chat_messages', chat: @chat
       - else
         .flex-1.flex.items-center.justify-center.text-gray-400


### PR DESCRIPTION
## Summary
- Add `disconnect()` cleanup for `requestAnimationFrame` to prevent memory leaks
- Add `console.warn` when scrollable parent not found for debugging
- Use `data-scroll-container` attribute for more reliable element selection
- Keep CSS class fallback for backwards compatibility

Follow-up to PR #160 based on code review feedback.

## Test plan
- [ ] Open chat page, verify auto-scroll works
- [ ] Switch between chats, verify no memory leaks in devtools
- [ ] Check console for warnings if scroll container not found

🤖 Generated with [Claude Code](https://claude.com/claude-code)